### PR TITLE
Feature #161415609 - Added table creation script for in-memory H2 DB

### DIFF
--- a/db/gxasc-schema.sql
+++ b/db/gxasc-schema.sql
@@ -66,3 +66,18 @@ CREATE VIEW scxa_public_experiment AS
   FROM scxa_experiment
   WHERE scxa_experiment.private IS FALSE
 );
+
+-- This table replaces the materialised view used in the Postgres DB
+CREATE TABLE scxa_marker_gene_stats
+(
+  experiment_accession VARCHAR(255) NOT NULL,
+  gene_id VARCHAR(255) NOT NULL,
+  k_where_marker INTEGER NOT NULL,
+  cluster_id_where_marker INTEGER NOT NULL,
+  cluster_id INTEGER NOT NULL,
+  marker_p_value DOUBLE PRECISION NOT NULL,
+  mean_expression DOUBLE PRECISION NOT NULL,
+  median_expression DOUBLE PRECISION NOT NULL,
+  CONSTRAINT marker_gene_stats_pkey
+  PRIMARY KEY (experiment_accession, gene_id, k_where_marker, cluster_id)
+);


### PR DESCRIPTION
Added script to create a marker_gene_stats table for the in-memory H2 DB creation, rather than a materialised view. Materialised views are not currently supported by H2.

Sorry... made a right mess of this repository with all my merging and reverting.