### PR TITLE
Feature #167319925 – Remove title field

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,23 @@
 Schemas for the database and SolrCloud servers used by [Expression Atlas](https://www.ebi.ac.uk/gxa) and [Single Cell
 Expression Atlas](https://www.ebi.ac.uk/gxa/sc).
 
-This is a central repository used by the web application to bootstrap the embedded database and Solr server for
-testing, and to initialise a fresh (PostgreSQL) database and SolrCloud cluster to be used by either or both flavours of
-Expression Atlas.
+This is a central repository used by the web application to bootstrap the embedded database and Solr server in the
+testing environment, and to initialise a fresh (PostgreSQL) database and SolrCloud cluster to be used by either flavour
+of Expression Atlas.
 
 In the `db` directory there is a `shared-schema.sql` file that is needed by both Expression Atlas and Single Cell
 Expression Atlas, used to display array designs and design elements of a gene in the [bioentity information
 card](https://github.com/ebi-gene-expression-group/atlas-bioentity-information).
+
+## Migrations
+
+We use [Flyway](https://flywaydb.org/) to version-control both single cell and bulk Expression Atlas databases. To
+apply new migrations to a database, either from `gxa` or `scxa`, applied to bulk Expression Atlas and Single Cell
+Expression Atlas, respectively, run the following command (fill in the variables as needed):
+```bash
+flyway migrate -url=jdbc:postgresql://${HOST}:5432/${DB} -user=${USER} -password=${PASSWORD} -locations=filesystem:`pwd`
+```
+
+The [`info`](https://flywaydb.org/documentation/command/info) and
+[`repair`](https://flywaydb.org/documentation/command/repair) commands are helpful to troubleshoot issues (e.g.
+checksum mismatches).

--- a/db/gxa-schema.sql
+++ b/db/gxa-schema.sql
@@ -9,7 +9,6 @@ CREATE TABLE experiment
   species VARCHAR(255),
   access_key CHAR(36) NOT NULL,
   private BOOLEAN,
-  load_date TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
   last_update TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
   pubmed_ids VARCHAR(255),
   dois VARCHAR(255)

--- a/db/gxa-schema.sql
+++ b/db/gxa-schema.sql
@@ -9,8 +9,8 @@ CREATE TABLE experiment
   species VARCHAR(255),
   access_key CHAR(36) NOT NULL,
   private BOOLEAN,
+  load_date TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
   last_update TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
-  title VARCHAR(500),
   pubmed_ids VARCHAR(255),
   dois VARCHAR(255)
 );

--- a/db/gxasc-schema.sql
+++ b/db/gxasc-schema.sql
@@ -20,7 +20,6 @@ CREATE TABLE scxa_experiment
   species VARCHAR(255) NOT NULL,
   access_key CHAR(36) NOT NULL,
   private BOOLEAN DEFAULT TRUE,
-  load_date TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
   last_update TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
   pubmed_ids VARCHAR(255),
   dois VARCHAR(255)

--- a/db/gxasc-schema.sql
+++ b/db/gxasc-schema.sql
@@ -20,9 +20,9 @@ CREATE TABLE scxa_experiment
   species VARCHAR(255) NOT NULL,
   access_key CHAR(36) NOT NULL,
   private BOOLEAN DEFAULT TRUE,
+  load_date TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
   last_update TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
   pubmed_ids VARCHAR(255),
-  title VARCHAR(500),
   dois VARCHAR(255)
 );
 

--- a/flyway/gxa/migrations/V4__gxa-remove-experiment-title.sql
+++ b/flyway/gxa/migrations/V4__gxa-remove-experiment-title.sql
@@ -1,0 +1,2 @@
+ALTER TABLE experiment
+DROP COLUMN title;

--- a/flyway/scxa/migrations/V4__scxa-remove-experiment-title.sql
+++ b/flyway/scxa/migrations/V4__scxa-remove-experiment-title.sql
@@ -1,0 +1,2 @@
+ALTER TABLE scxa_experiment
+DROP COLUMN title;


### PR DESCRIPTION
The title field became a legacy column a couple of releases ago, so I decided to remove it to avoid any head-scratching, since the title is pulled straight from the IDF file.

I added a section in the README file that explains how to migrate DBs using Flyway.