### PR TITLE
Drop foreign key constraint on scxa_cell_group

### DIFF
--- a/flyway/scxa/migrations/V12__scxa-remove-foreign-key-constraint.sql
+++ b/flyway/scxa/migrations/V12__scxa-remove-foreign-key-constraint.sql
@@ -1,0 +1,2 @@
+
+ALTER TABLE scxa_cell_group DROP CONSTRAINT scxa_cell_group_experiment_accession_fkey;

--- a/flyway/scxa/migrations/V12__scxa-remove-foreign-key-constraint.sql
+++ b/flyway/scxa/migrations/V12__scxa-remove-foreign-key-constraint.sql
@@ -1,2 +1,1 @@
-
 ALTER TABLE scxa_cell_group DROP CONSTRAINT scxa_cell_group_experiment_accession_fkey;


### PR DESCRIPTION
If the foreign key constraint is there, we need to load the experiment on the web application before processing the cell groups, creating a circular dependency.

@pinin4fjords Is this foreign key necessary? Maybe it‘s better to enforce it from `scxa_analytics` instead? Notice that in any case you’ll introduce a necessary order in which scripts need to be run.