### PR TITLE
Add indices to cell groups columns in marker-related tables

### DIFF
--- a/flyway/scxa/migrations/V12__scxa-add-markers-stats-indices.sql
+++ b/flyway/scxa/migrations/V12__scxa-add-markers-stats-indices.sql
@@ -1,0 +1,6 @@
+
+CREATE INDEX scxa_cell_group_marker_gene_stats_cell_group_id 
+    ON scxa_cell_group_marker_gene_stats(cell_group_id);
+
+CREATE INDEX scxa_cell_group_marker_genes_cell_group_id 
+    ON scxa_cell_group_marker_genes(cell_group_id);


### PR DESCRIPTION
This migration adds indices to the cell_group_id columns the marker gene related tables. I believe the absence of such is behind low delete times we're seeing during load processes, where I'm seeing 'seq scans' from EXPLAIN_ANALYZE (i.e. the compound indices we have of cell group id with other fields are not being used). 
