### PR TITLE
Add index for other foreign key on stats table

### DIFF
--- a/flyway/scxa/migrations/V13__scxa-add-more-markers-stats-indices.sql
+++ b/flyway/scxa/migrations/V13__scxa-add-more-markers-stats-indices.sql
@@ -1,0 +1,3 @@
+
+CREATE INDEX scxa_cell_group_marker_gene_stats_marker_id 
+    ON scxa_cell_group_marker_gene_stats(marker_id);


### PR DESCRIPTION
Further to https://github.com/ebi-gene-expression-group/atlas-schemas/pull/16, add an index on the other foreign key used in the stats table. 