### PR TITLE
Add new binary JSON field for params in scxa coordinates table

### DIFF
--- a/flyway/scxa/migrations/V14__scxa_add_json_coords_param.sql
+++ b/flyway/scxa/migrations/V14__scxa_add_json_coords_param.sql
@@ -1,0 +1,2 @@
+ALTER TABLE scxa_coords
+ADD COLUMN json_parameterisation JSONB DEFAULT NULL;


### PR DESCRIPTION
Adds a JSON field for parameterisation in the coords table. I figure binary is the way to go for speed of retrieval, while accepting a slower storage speed.