### PR TITLE
Add indexing migration for coords table

### DIFF
--- a/flyway/scxa/migrations/V16__coords_query_indices.sql
+++ b/flyway/scxa/migrations/V16__coords_query_indices.sql
@@ -1,0 +1,5 @@
+CREATE INDEX scxa_cell_group_membership_cell_id 
+    ON scxa_cell_group_membership(cell_id)
+
+CREATE INDEX scxa_coords_experiment_accession_method 
+    ON scxa_coords(experiment_accession, method)

--- a/flyway/scxa/migrations/V16__coords_query_indices.sql
+++ b/flyway/scxa/migrations/V16__coords_query_indices.sql
@@ -1,5 +1,5 @@
 CREATE INDEX scxa_cell_group_membership_cell_id 
-    ON scxa_cell_group_membership(cell_id)
+    ON scxa_cell_group_membership(cell_id);
 
 CREATE INDEX scxa_coords_experiment_accession_method 
-    ON scxa_coords(experiment_accession, method)
+    ON scxa_coords(experiment_accession, method);


### PR DESCRIPTION
The indexes I'm adding here are designed to optimise queries like the following.

# Get coords with cell group memberships for specific perplexity values

```
SELECT 
c.cell_id, 
c.x, 
c.y, 
g.value AS cluster_id 
FROM 
scxa_cell_group_membership m, 
scxa_coords c, 
scxa_cell_group g 
WHERE
    c.experiment_accession='$experiment_accession' AND 
    c.method='$method' AND
    c.parameterisation->0->>'perplexity'='$perplexity' AND
    c.cell_id=m.cell_id AND
    m.cell_group_id=g.id
    and g.variable='$variable'"
```

This is analogous to the current t-SNE query and should return the same table.


# Get a list of parameterisations for a specific method

```
SELECT DISTINCT 
    parameterisation AS params 
FROM scxa_coords
WHERE
    experiment_accession='E-CURD-55' AND 
    method='tsne';
```

This gets you:

```
        params        
----------------------
 [{"perplexity": 5}]
 [{"perplexity": 1}]
 [{"perplexity": 15}]
 [{"perplexity": 20}]
 [{"perplexity": 10}]
 [{"perplexity": 45}]
 [{"perplexity": 35}]
 [{"perplexity": 50}]
 [{"perplexity": 30}]
 [{"perplexity": 40}]
 [{"perplexity": 25}]
(11 rows)
```

# Get a list of 'first' params and values for a given experiment and method

```
SELECT DISTINCT 
    key,value 
FROM
   scxa_coords, lateral jsonb_each(parameterisation->0) 
WHERE 
   experiment_accession='E-CURD-55' AND 
   method='tsne';
```

This gets you:

```
    key     | value 
------------+-------
 perplexity | 40
 perplexity | 35
 perplexity | 25
 perplexity | 15
 perplexity | 30
 perplexity | 20
 perplexity | 50
 perplexity | 45
 perplexity | 1
 perplexity | 5
 perplexity | 10
(11 rows)
```

(to handle cases where there may not be a perplexity).

This one is a bit slow (a few seconds)- it may be better to get all the param JSONs and deal with it on the application side.

# Get a list of perplexity values for an experiment

```
SELECT DISTINCT 
    parameterisation->0->'perplexity' AS perplexity 
FROM scxa_coords 
WHERE 
    experiment_accession='E-CURD-55' AND 
    method='tsne';
```

This gets you:

```
 perplexity 
------------
 35
 45
 5
 30
 50
 40
 1
 10
 20
 25
 15
(11 rows)
```
