### PR TITLE
Add scx_coords table creation script to create table for tests

### DIFF
--- a/db/gxasc-schema.sql
+++ b/db/gxasc-schema.sql
@@ -121,3 +121,16 @@ CREATE TABLE scxa_cell_group_marker_gene_stats
   median_expression DOUBLE PRECISION NOT NULL,
   UNIQUE (gene_id, cell_group_id, marker_id, expression_type)
 );
+
+-- scxa_coords table
+
+CREATE TYPE "JSONB" AS TEXT;
+create table scxa_coords
+(
+    experiment_accession varchar(255) not null,
+    method               varchar(255) not null,
+    cell_id              varchar(255) not null,
+    x                    double precision,
+    y                    double precision,
+    parameterisation    JSONB NOT NULL
+);


### PR DESCRIPTION
This PR contains a SQL script that takes care of creating the `scxa_coords` table for the H2 database. We are using H2 as a test instance, so we need this script to tell H2 about `scxa_coords` to load fixtures.
