### PR TITLE
Deletes the table scxa_tsne in the database.

### DIFF
--- a/flyway/scxa/migrations/V17__scxa-remove-tsne-table.sql
+++ b/flyway/scxa/migrations/V17__scxa-remove-tsne-table.sql
@@ -1,0 +1,1 @@
+DROP TABLE scxa_tsne;


### PR DESCRIPTION
Alternatively  "TRUNCATE TABLE scxa_tsne;" could have been used to delete the data inside a table, but not the table itself.