### PR TITLE
Use atlas-schemas-base as container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,8 @@
-FROM continuumio/miniconda3:4.8.2
-# debian
+FROM quay.io/ebigxa/atlas-schemas-base:1.0
+# based on u-mamba
+# To modify base dependencies,
+# edit https://github.com/ebi-gene-expression-group/atlas-containers/tree/master/atlas-schemas-base
 
-RUN /opt/conda/bin/conda config --add channels defaults && \
-    /opt/conda/bin/conda config --add channels conda-forge && \
-    /opt/conda/bin/conda config --add channels bioconda && \
-    /opt/conda/bin/conda install openjdk
-
-USER root
-# RUN apk update && apk add postgresql-client bash wget nodejs bats
-RUN apt-get update && apt-get install -y postgresql-client wget nodejs bats
-RUN wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/6.3.2/flyway-commandline-6.3.2-linux-x64.tar.gz | tar xvz && ln -s `pwd`/flyway-6.3.2/flyway /usr/local/bin
-
-ENV PATH "/bin:/sbin:/usr/bin:/usr/local/bin:/opt/conda/bin"
+COPY tests /usr/local/tests
+COPY flyway/scxa /usr/local/flyway/scxa
+COPY flyway/gxa /usr/local/flyway/gxa

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM quay.io/ebigxa/atlas-schemas-base:1.0
-# based on u-mamba
-# To modify base dependencies,
-# edit https://github.com/ebi-gene-expression-group/atlas-containers/tree/master/atlas-schemas-base
-
-COPY tests /usr/local/tests
-COPY flyway/scxa /usr/local/flyway/scxa
-COPY flyway/gxa /usr/local/flyway/gxa

--- a/README.md
+++ b/README.md
@@ -24,45 +24,72 @@ The [`info`](https://flywaydb.org/documentation/command/info) and
 [`repair`](https://flywaydb.org/documentation/command/repair) commands are helpful to troubleshoot issues (e.g.
 checksum mismatches).
 
+### How to use it without having to deal with dependencies
+
+You can use flyway as installed in the `quay.io/ebigxa/atlas-schemas-base` container
+(this is the same container used to run the tests). You will need:
+
+- A checkout of this repo
+- Mount the location of the flyway/[gxa|scxa] directory inside the container
+- Specify the database connection
+
+This is achieved like this (make sure to replace db_host and db_name):
+
+```
+# go to the root directory of this repo
+export APP=gxa
+export DB_CONNECTION_URL=jdbc:postgresql://db_host:5432/db_name
+export USER=<db_user>
+export PASSWORD=<db_password>
+# Make sure you fill in the above ^^^^^^
+export LOCATION_IN_CONTAINER=/flyway/$APP
+docker run -it -v $( pwd )/flyway/$APP:$LOCATION_IN_CONTAINER \
+  quay.io/ebigxa/atlas-schemas-base \
+  flyway migrate -url=$DB_CONNECTION_URL -user=${USER} -password=${PASSWORD} -locations=filesystem:$LOCATION_IN_CONTAINER
+```
+
+Note that changes in this repo don't require changes in that container unless that
+we need a new flyway version.
+
 ## Common queries
 
 ### Select all experiments for a gene
 
 ```
-SELECT 
-    experiment_accession 
-FROM 
-    scxa_cell_group_marker_genes m 
+SELECT
+    experiment_accession
+FROM
+    scxa_cell_group_marker_genes m
     JOIN scxa_cell_group g ON m.cell_group_id=g.id
     JOIN experiment e ON g.experiment_accession = e.accession
-WHERE 
-    e.private=FALSE AND 
-    m.gene_id=':gene_id' 
+WHERE
+    e.private=FALSE AND
+    m.gene_id=':gene_id'
 GROUP BY experiment_accession
 ```
 
 ### Select clusters for significant genes
 
 ```
-SELECT 
-    variable as k, 
-    value as cluster_id 
-FROM 
-    scxa_cell_group g 
+SELECT
+    variable as k,
+    value as cluster_id
+FROM
+    scxa_cell_group g
     JON scxa_cell_group_marker_genes m ON g.id = m.cell_group_id
 WHERE(
-    m.gene_id=':gene_id' 
-    AND marker_probability < :threshold AND 
+    m.gene_id=':gene_id'
+    AND marker_probability < :threshold AND
     g.experiment_accession=':experiment_accession' AND (
-      g.variable=':preferred_K' OR 
+      g.variable=':preferred_K' OR
       m.marker_probability IN (
-        SELECT 
-          MIN(marker_probability) 
-        FROM 
-          scxa_cell_group, 
-          scxa_cell_group_marker_genes 
-        WHERE 
-          experiment_accession = ':experiment_accession' AND 
+        SELECT
+          MIN(marker_probability)
+        FROM
+          scxa_cell_group,
+          scxa_cell_group_marker_genes
+        WHERE
+          experiment_accession = ':experiment_accession' AND
           gene_id=':gene_id'
         )
     )
@@ -72,33 +99,33 @@ WHERE(
 ### Select coordinates with expression of a given gene
 
 ```
-SELECT 
-    c.cell_id, 
-    c.x, 
-    c.y, 
+SELECT
+    c.cell_id,
+    c.x,
+    c.y,
     a.expression_level
-FROM 
+FROM
     scxa_coords c  
-    LEFT JOIN scxa_analytics a ON 
-        c.experiment_accession=a.experiment_accession AND 
+    LEFT JOIN scxa_analytics a ON
+        c.experiment_accession=a.experiment_accession AND
         c.cell_id=a.cell_id AND
         a.gene_id=':gene_id'
-WHERE 
-    c.experiment_accession=':experiment_accession' AND 
-    c.method=':method' AND 
-    c.parameterisation->0->>'perplexity'=':perplexity' 
+WHERE
+    c.experiment_accession=':experiment_accession' AND
+    c.method=':method' AND
+    c.parameterisation->0->>'perplexity'=':perplexity'
 ```
 
 ### Select coordinates with a cell group membership
 
 ```
-  SELECT 
-    c.cell_id, 
-    c.x, 
-    c.y, 
+  SELECT
+    c.cell_id,
+    c.x,
+    c.y,
     g.value as cluster_id
-FROM 
-    scxa_cell_group g 
+FROM
+    scxa_cell_group g
     JOIN scxa_cell_group_membership m ON
         g.id = m.cell_group_id AND
         g.experiment_accession = ':experiment_accession' AND
@@ -106,7 +133,7 @@ FROM
     RIGHT JOIN scxa_coords c ON
         m.cell_id=c.cell_id AND
         m.experiment_accession=c.experiment_accession
-    WHERE 
+    WHERE
         c.method=':method' AND
         c.parameterisation->0->>'perplexity'=':perplexity' AND
         c.experiment_accession=':experiment_accession'
@@ -117,24 +144,24 @@ Starting from the cell group and right-joining to get the coordinates ensures we
 ### Summary stats for cell group markers
 
 ```
-SELECT 
-  g.experiment_accession, 
-  m.gene_id, 
-  g.variable as k_where_marker, 
-  h.value as cluster_id_where_marker, 
-  g.value as cluster_id, 
-  m.marker_probability as marker_p_value, 
-  s.mean_expression, s.median_expression 
+SELECT
+  g.experiment_accession,
+  m.gene_id,
+  g.variable as k_where_marker,
+  h.value as cluster_id_where_marker,
+  g.value as cluster_id,
+  m.marker_probability as marker_p_value,
+  s.mean_expression, s.median_expression
 FROM
- 	scxa_cell_group_marker_gene_stats s 
+ 	scxa_cell_group_marker_gene_stats s
   JOIN scxa_cell_group g on s.cell_group_id=g.id
   JOIN scxa_cell_group_marker_genes m ON s.marker_id=m.id
-  JOIN scxa_cell_group h ON m.cell_group_id = h.id 
-WHERE 
-  g.experiment_accession=':experiment_accession' and 
-  m.marker_probability < 0.05 and 
-  g.variable = ':k' and 
-  expression_type=0 
+  JOIN scxa_cell_group h ON m.cell_group_id = h.id
+WHERE
+  g.experiment_accession=':experiment_accession' and
+  m.marker_probability < 0.05 and
+  g.variable = ':k' and
+  expression_type=0
 ORDER BY m.marker_probability
 ```
 
@@ -143,14 +170,12 @@ Note: The marker stats table references the cell group table twice, once directl
 ### Find cell groupings with significant markers
 
 ```
-SELECT DISTINCT 
-  h.variable as k_where_marker 
-FROM 
-  scxa_cell_group_marker_genes m, 
-  JOIN scxa_cell_group h ON m.cell_group_id = h.id 
-WHERE 
-  h.experiment_accession=':experiment_accession' 
-  and m.marker_probability < 0.05 
+SELECT DISTINCT
+  h.variable as k_where_marker
+FROM
+  scxa_cell_group_marker_genes m,
+  JOIN scxa_cell_group h ON m.cell_group_id = h.id
+WHERE
+  h.experiment_accession=':experiment_accession'
+  and m.marker_probability < 0.05
 ORDER BY k_where_marker ASC
-
-

--- a/run_tests_with_containers.sh
+++ b/run_tests_with_containers.sh
@@ -10,6 +10,6 @@ docker run --name postgres --net mynet -e POSTGRES_PASSWORD=postgresPass -e POST
 docker run --net mynet -i \
   -v $(pwd)/tests:/usr/local/tests \
   -v $(pwd)/flyway/scxa:/usr/local/flyway/scxa \
-  -v $(pwd)/flyway/gxa:/usr/local/flyway/gxa
+  -v $(pwd)/flyway/gxa:/usr/local/flyway/gxa \
   -e dbConnection=$dbConnection --entrypoint=/usr/local/tests/run_tests.sh \
   quay.io/ebigxa/atlas-schemas-base:1.0

--- a/run_tests_with_containers.sh
+++ b/run_tests_with_containers.sh
@@ -7,4 +7,4 @@ docker network rm mynet
 docker network create mynet
 docker run --name postgres --net mynet -e POSTGRES_PASSWORD=postgresPass -e POSTGRES_USER=scxa -e POSTGRES_DB=scxa-test -p 5432:5432 -d postgres:10.3-alpine
 docker build -t test/atlas-flyway-schemas .
-docker run --net mynet -i -v $( pwd )/tests:/usr/local/tests -e dbConnection=$dbConnection -v $( pwd )/flyway/scxa:/usr/local/flyway/scxa -v $( pwd )/flyway/gxa:/usr/local/flyway/gxa --entrypoint=/usr/local/tests/run_tests.sh test/atlas-flyway-schemas
+docker run --net mynet -i -e dbConnection=$dbConnection --entrypoint=/usr/local/tests/run_tests.sh test/atlas-flyway-schemas

--- a/run_tests_with_containers.sh
+++ b/run_tests_with_containers.sh
@@ -6,5 +6,10 @@ docker stop postgres && docker rm postgres
 docker network rm mynet
 docker network create mynet
 docker run --name postgres --net mynet -e POSTGRES_PASSWORD=postgresPass -e POSTGRES_USER=scxa -e POSTGRES_DB=scxa-test -p 5432:5432 -d postgres:10.3-alpine
-docker build -t test/atlas-flyway-schemas .
-docker run --net mynet -i -e dbConnection=$dbConnection --entrypoint=/usr/local/tests/run_tests.sh test/atlas-flyway-schemas
+
+docker run --net mynet -i \
+  -v $(pwd)/tests:/usr/local/tests \
+  -v $(pwd)/flyway/scxa:/usr/local/flyway/scxa \
+  -v $(pwd)/flyway/gxa:/usr/local/flyway/gxa
+  -e dbConnection=$dbConnection --entrypoint=/usr/local/tests/run_tests.sh \
+  quay.io/ebigxa/atlas-schemas-base:1.0

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -15,7 +15,7 @@ make_flyway_credentials(){
 	HOST=$(echo $dbConnection | sed 's+.*\@\(.*\)/.*+\1+')
 	DB=$(echo $dbConnection | sed 's+.*/\(.*\)+\1+')
 
-	flyway migrate -schemas=$schema -url=jdbc:postgresql://${HOST}:5432/${DB} -user=${USER} -password=${PASS} -locations=filesystem:$( pwd )/usr/local/flyway/${schema}
+	flyway migrate -schemas=$schema -url=jdbc:postgresql://${HOST}:5432/${DB} -user=${USER} -password=${PASS} -locations=filesystem:/usr/local/flyway/${schema}
 }
 
 # SCXA


### PR DESCRIPTION
This PR removes the building step of the container from here and uses all the time an existing container with the dependencies, reducing testing time hopefully (although the separate container was done so that it can be used in other repos).