### PR TITLE
Add migration to drop defunct tables

### DIFF
--- a/flyway/scxa/migrations/V18__remove_clusters_markers_tables.sql
+++ b/flyway/scxa/migrations/V18__remove_clusters_markers_tables.sql
@@ -1,3 +1,4 @@
 DROP MATERIALIZED VIEW scxa_marker_gene_stats;
+DROP MATERIALIZED VIEW scxa_top_5_marker_genes_per_cluster;
 DROP TABLE scxa_cell_clusters;
 DROP TABLE scxa_marker_genes;

--- a/flyway/scxa/migrations/V18__remove_clusters_markers_tables.sql
+++ b/flyway/scxa/migrations/V18__remove_clusters_markers_tables.sql
@@ -1,0 +1,2 @@
+DROP TABLE scxa_cell_clusters;
+DROP TABLE scxa_marker_genes;

--- a/flyway/scxa/migrations/V18__remove_clusters_markers_tables.sql
+++ b/flyway/scxa/migrations/V18__remove_clusters_markers_tables.sql
@@ -1,3 +1,3 @@
-DROP MATERIALIZED VIEW scxa_marker_gene_stats
+DROP MATERIALIZED VIEW scxa_marker_gene_stats;
 DROP TABLE scxa_cell_clusters;
 DROP TABLE scxa_marker_genes;

--- a/flyway/scxa/migrations/V18__remove_clusters_markers_tables.sql
+++ b/flyway/scxa/migrations/V18__remove_clusters_markers_tables.sql
@@ -1,2 +1,3 @@
+DROP MATERIALIZED VIEW scxa_marker_gene_stats
 DROP TABLE scxa_cell_clusters;
 DROP TABLE scxa_marker_genes;


### PR DESCRIPTION
Drop long-defunct tables previously used to store clusters and markers. Paired with changes to prevent attempts to load these tables - see https://github.com/ebi-gene-expression-group/db-scxa/pull/61