### PR TITLE
Add scxa_coords backward compatibility Fix

### DIFF
--- a/flyway/scxa/migrations/V20__add_scxa_coords_backward_compatibility.sql
+++ b/flyway/scxa/migrations/V20__add_scxa_coords_backward_compatibility.sql
@@ -1,0 +1,21 @@
+-- Rename latest scxa_coords table with '_latest' to CREATE old scxa_coords table with old columns for the backward compatibility
+
+ALTER TABLE scxa_coords RENAME TO scxa_coords_latest;
+
+-- CREATE old scxa_coords table with all five columns
+
+CREATE TABLE if NOT EXISTS scxa_coords
+(
+    experiment_accession VARCHAR(255) NOT NULL,
+    method VARCHAR(255) NOT NULL,
+    cell_id VARCHAR(255) NOT NULL,
+    x DOUBLE PRECISION,
+    y DOUBLE PRECISION,
+    parameterisation jsonb NOT NULL);
+
+CREATE index if NOT EXISTS scxa_coords_parameterisation
+	ON scxa_coords USING gin (parameterisation);
+
+CREATE index if NOT EXISTS scxa_coords_experiment_accession_method
+	ON scxa_coords (experiment_accession, method);
+


### PR DESCRIPTION
- After applying the 'V19' flyway migration script, the latest scxa_coords table schema got changed, which leads to breaking web application in many places along with tests.

- It requires a lot of effort to refactor code. So, after discussion with Alfonso, we have added this 'V20' flyway script to fix the backward compatibility of the scxa_coords table with the previous table schema.

- Here is the PR, where we mentioned all the affected` scxa_coords ` table related queries with the latest 'V19' script -https://github.com/ebi-gene-expression-group/atlas-schemas/pull/27
- I have tested 'V20' script in my local machine, it is working as expected, ann data new tests and the existing tests got passed.