### PR TITLE
Add GXA marker gene table

### DIFF
--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -2,13 +2,11 @@ CREATE TABLE gxa_marker_gene
 (
     experiment_accession VARCHAR(255) CHECK (experiment_accession LIKE 'E-%') NOT NULL,
     assay VARCHAR(255) NOT NULL,
-    assay_id VARCHAR(255) NOT NULL,
     gene_id VARCHAR(255) NOT NULL,
-    gene_name VARCHAR(255) NOT NULL,
-    marker_gene_rank INTEGER,
-    expression_level FLOAT NOT NULL,
-    expression_unit VARCHAR(8) NOT NULL,
-    number_assays INTEGER NOT NULL,
     specificity_score FLOAT,
+    marker_gene_rank INTEGER,
+    expression_unit VARCHAR(8) NOT NULL,
+    expression_level FLOAT NOT NULL,
+    gene_name VARCHAR(255) NOT NULL,
     CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id)
 );

--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -5,7 +5,7 @@ CREATE TABLE gxa_marker_gene
     assay_id VARCHAR(255) NOT NULL,
     gene_id VARCHAR(255) NOT NULL,
     gene_name VARCHAR(255) NOT NULL,
-    gene_rank INTEGER,
+    marker_gene_rank INTEGER,
     expression_level FLOAT NOT NULL,
     expression_unit VARCHAR(8) NOT NULL,
     sample_number INTEGER NOT NULL,

--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -2,6 +2,7 @@ CREATE TABLE gxa_marker_gene
 (
     experiment_accession VARCHAR(255) CHECK (experiment_accession LIKE 'E-%') NOT NULL,
     assay VARCHAR(255) NOT NULL,
+    gene_id VARCHAR(255) NOT NULL,
     gene_rank INTEGER NOT NULL,
     expression_value FLOAT NOT NULL,
     expression_unit VARCHAR(8) NOT NULL

--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -3,9 +3,10 @@ CREATE TABLE gxa_marker_gene
     experiment_accession VARCHAR(255) CHECK (experiment_accession LIKE 'E-%') NOT NULL,
     assay VARCHAR(255) NOT NULL,
     gene_id VARCHAR(255) NOT NULL,
+    gene_name VARCHAR(255) NOT NULL,
     gene_rank INTEGER NOT NULL,
     expression_value FLOAT NOT NULL,
     expression_unit VARCHAR(8) NOT NULL,
-    gene_name VARCHAR(255) NOT NULL,
+    sample_number INTEGER NOT NULL,
     CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id, gene_rank)
 );

--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -5,10 +5,10 @@ CREATE TABLE gxa_marker_gene
     assay_id VARCHAR(255) NOT NULL,
     gene_id VARCHAR(255) NOT NULL,
     gene_name VARCHAR(255) NOT NULL,
-    gene_rank INTEGER NOT NULL,
-    expression_value FLOAT NOT NULL,
+    gene_rank INTEGER,
+    expression_level FLOAT NOT NULL,
     expression_unit VARCHAR(8) NOT NULL,
     sample_number INTEGER NOT NULL,
-    specificity FLOAT NOT NULL,
-    CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id, gene_rank)
+    specificity FLOAT,
+    CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id)
 );

--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -6,5 +6,5 @@ CREATE TABLE gxa_marker_gene
     gene_rank INTEGER NOT NULL,
     expression_value FLOAT NOT NULL,
     expression_unit VARCHAR(8) NOT NULL,
-    ADD CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id, gene_rank);
+    CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id, gene_rank);
 );

--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -5,5 +5,6 @@ CREATE TABLE gxa_marker_gene
     gene_id VARCHAR(255) NOT NULL,
     gene_rank INTEGER NOT NULL,
     expression_value FLOAT NOT NULL,
-    expression_unit VARCHAR(8) NOT NULL
+    expression_unit VARCHAR(8) NOT NULL,
+    ADD CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id, gene_rank);
 );

--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -6,5 +6,5 @@ CREATE TABLE gxa_marker_gene
     gene_rank INTEGER NOT NULL,
     expression_value FLOAT NOT NULL,
     expression_unit VARCHAR(8) NOT NULL,
-    CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id, gene_rank);
+    CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id, gene_rank)
 );

--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -8,7 +8,7 @@ CREATE TABLE gxa_marker_gene
     marker_gene_rank INTEGER,
     expression_level FLOAT NOT NULL,
     expression_unit VARCHAR(8) NOT NULL,
-    sample_number INTEGER NOT NULL,
+    number_assays INTEGER NOT NULL,
     specificity_score FLOAT,
     CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id)
 );

--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -2,11 +2,13 @@ CREATE TABLE gxa_marker_gene
 (
     experiment_accession VARCHAR(255) CHECK (experiment_accession LIKE 'E-%') NOT NULL,
     assay VARCHAR(255) NOT NULL,
+    assay_id VARCHAR(255) NOT NULL,
     gene_id VARCHAR(255) NOT NULL,
     gene_name VARCHAR(255) NOT NULL,
     gene_rank INTEGER NOT NULL,
     expression_value FLOAT NOT NULL,
     expression_unit VARCHAR(8) NOT NULL,
     sample_number INTEGER NOT NULL,
+    specificity FLOAT NOT NULL,
     CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id, gene_rank)
 );

--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -8,5 +8,5 @@ CREATE TABLE gxa_marker_gene
     expression_unit VARCHAR(8) NOT NULL,
     expression_level FLOAT NOT NULL,
     gene_name VARCHAR(255) NOT NULL,
-    CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id)
+    CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id, expression_unit)
 );

--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -6,5 +6,6 @@ CREATE TABLE gxa_marker_gene
     gene_rank INTEGER NOT NULL,
     expression_value FLOAT NOT NULL,
     expression_unit VARCHAR(8) NOT NULL,
+    gene_name VARCHAR(255) NOT NULL,
     CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id, gene_rank)
 );

--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -9,6 +9,6 @@ CREATE TABLE gxa_marker_gene
     expression_level FLOAT NOT NULL,
     expression_unit VARCHAR(8) NOT NULL,
     sample_number INTEGER NOT NULL,
-    specificity FLOAT,
+    specificity_score FLOAT,
     CONSTRAINT gxa_marker_gene_pkey PRIMARY KEY (experiment_accession, assay, gene_id)
 );

--- a/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
+++ b/flyway/gxa/migrations/V9__gxa-create-exp-design.sql
@@ -1,0 +1,8 @@
+CREATE TABLE gxa_marker_gene
+(
+    experiment_accession VARCHAR(255) CHECK (experiment_accession LIKE 'E-%') NOT NULL,
+    assay VARCHAR(255) NOT NULL,
+    gene_rank INTEGER NOT NULL,
+    expression_value FLOAT NOT NULL,
+    expression_unit VARCHAR(8) NOT NULL
+);


### PR DESCRIPTION
This PR introduces a new SQL migration to create a table for GXA marker gene data.